### PR TITLE
Modified system dropdown to support case-insensitive searching.

### DIFF
--- a/ERA.pyw
+++ b/ERA.pyw
@@ -202,7 +202,7 @@ class era(wx.Frame):
 
 	def match_partial_system(self, text):
 		for system in era.current_region:
-			if system['name'].startswith(text):
+			if bool(re.match(text, system['name'], re.I)):
 				return system['name']
 		return None
 


### PR DESCRIPTION
i.e. you can type "ya0" for YA0-XJ or "wuz" for WUZ-WM. 

It's the little things. 
