### PR TITLE
Update mac os logs path for wine

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -38,7 +38,7 @@ class EVEDir(object):
                 # If we can't use pywin32, just fall back to a guess
                 return os.path.join(os.path.expanduser('~'), 'Documents', 'EVE')
         elif system == "Darwin":
-            return os.path.expanduser('~/Library/Application Support/EVE Online/p_drive/User/My Documents/EVE')
+            return os.path.expanduser('~/Documents/EVE')
 
     @ClassProperty
     @classmethod


### PR DESCRIPTION
Since migration of eve launcher from using cider to wine, the location
for log files have been changed.

Using wine will soon (if not already) be mandatory for all mac users.
